### PR TITLE
Update param annotation and apply ktlint

### DIFF
--- a/app/src/main/java/model/Course.kt
+++ b/app/src/main/java/model/Course.kt
@@ -32,22 +32,22 @@ import timber.log.Timber
  * @author Quang Dao
  * @since 1.0.0
  *
- * @param term          Term this class is for
- * @param subject       Course's 4-letter subject (ex: MATH)
- * @param number        Course's number (ex: 263)
- * @param title         Course title
- * @param crn           Course CRN number
- * @param section       Course section (ex: 001)
- * @param startTime     Course's start time
- * @param endTime       Course's end time
- * @param days          Days this course is on
- * @param type          Course type (ex: lecture, tutorial...)
- * @param location      Course location (generally building and room number)
- * @param instructor    Course's instructor's name
- * @param credits       Number of credits for this course
- * @param startDate     Course start date
- * @param endDate       Course end date
- * @param id            Unique Id for this course
+ * @property term          Term this class is for
+ * @property subject       Course's 4-letter subject (ex: MATH)
+ * @property number        Course's number (ex: 263)
+ * @property title         Course title
+ * @property crn           Course CRN number
+ * @property section       Course section (ex: 001)
+ * @property startTime     Course's start time
+ * @property endTime       Course's end time
+ * @property days          Days this course is on
+ * @property type          Course type (ex: lecture, tutorial...)
+ * @property location      Course location (generally building and room number)
+ * @property instructor    Course's instructor's name
+ * @property credits       Number of credits for this course
+ * @property startDate     Course start date
+ * @property endDate       Course end date
+ * @property id            Unique Id for this course
  */
 @Entity
 open class Course(

--- a/app/src/main/java/model/CourseResult.kt
+++ b/app/src/main/java/model/CourseResult.kt
@@ -27,9 +27,9 @@ import org.threeten.bp.LocalTime
  * @author Quang Dao
  * @since 1.0.0
  *
- * @param capacity          Course total capacity (for registration)
- * @param seatsRemaining    Number of seats remaining (for registration)
- * @param waitlistRemaining Number of waitlist spots remaining
+ * @property capacity          Course total capacity (for registration)
+ * @property seatsRemaining    Number of seats remaining (for registration)
+ * @property waitlistRemaining Number of waitlist spots remaining
  */
 @Entity
 class CourseResult(

--- a/app/src/main/java/model/RegistrationError.kt
+++ b/app/src/main/java/model/RegistrationError.kt
@@ -23,8 +23,8 @@ import timber.log.Timber
  * @author Julien Guerinet
  * @since 1.0.0
  *
- * @param crn     Course CRN with the error
- * @param message Error message
+ * @property crn     Course CRN with the error
+ * @property message Error message
  */
 class RegistrationError(
     private val crn: Int,

--- a/app/src/main/java/model/Semester.kt
+++ b/app/src/main/java/model/Semester.kt
@@ -27,13 +27,13 @@ import androidx.room.PrimaryKey
  * @author Julien Guerinet
  * @since 1.0.0
  *
- * @param id            Unique semester Id
- * @param term          Semester term
- * @param program       User's program for this semester
- * @param bachelor      User's bachelor's name for this semester
- * @param credits       Number of credits for this semester
- * @param gpa           Semester GPA
- * @param isFullTime    True if the user was full time during this semester, false otherwise
+ * @property id            Unique semester Id
+ * @property term          Semester term
+ * @property program       User's program for this semester
+ * @property bachelor      User's bachelor's name for this semester
+ * @property credits       Number of credits for this semester
+ * @property gpa           Semester GPA
+ * @property isFullTime    True if the user was full time during this semester, false otherwise
  */
 @Entity
 data class Semester(

--- a/app/src/main/java/model/Statement.kt
+++ b/app/src/main/java/model/Statement.kt
@@ -26,10 +26,10 @@ import org.threeten.bp.LocalDate
  * @author Quang Dao
  * @since 1.0.0
  *
- * @param date      Statement date
- * @param dueDate   Due date
- * @param amount    Total amount due or owed
- * @param id        Randomly generated Id for this statement, used as a primary key
+ * @property date      Statement date
+ * @property dueDate   Due date
+ * @property amount    Total amount due or owed
+ * @property id        Randomly generated Id for this statement, used as a primary key
  */
 @Entity
 data class Statement(

--- a/app/src/main/java/model/Term.kt
+++ b/app/src/main/java/model/Term.kt
@@ -25,8 +25,8 @@ import java.io.Serializable
  * @author Julien Guerinet
  * @since 1.0.0
  *
- * @param season    Term [Season]
- * @param year      Term year
+ * @property season    Term [Season]
+ * @property year      Term year
  */
 @Suppress("EqualsOrHashCode")
 class Term(val season: Season, val year: Int) : Serializable {

--- a/app/src/main/java/model/place/Category.kt
+++ b/app/src/main/java/model/place/Category.kt
@@ -27,9 +27,9 @@ import java.util.Locale
  * @author Julien Guerinet
  * @since 1.0.0
  *
- * @param id    Category Id
- * @param en    Category name in English
- * @param fr    Category name in French
+ * @property id    Category Id
+ * @property en    Category name in English
+ * @property fr    Category name in French
  */
 @Entity
 data class Category(

--- a/app/src/main/java/model/place/Place.kt
+++ b/app/src/main/java/model/place/Place.kt
@@ -26,13 +26,13 @@ import com.google.android.gms.maps.model.LatLng
  * @author Julien Guerinet
  * @since 1.0.0
  *
- * @param id            Place Id
- * @param name          Place name
- * @param categories    List of categories
- * @param address       Address of this place
- * @param courseName    Name of the place when listed under a course location
- * @param latitude      Latitude coordinate of this place
- * @param longitude     Longitude coordinate of this place
+ * @property id            Place Id
+ * @property name          Place name
+ * @property categories    List of categories
+ * @property address       Address of this place
+ * @property courseName    Name of the place when listed under a course location
+ * @property latitude      Latitude coordinate of this place
+ * @property longitude     Longitude coordinate of this place
  */
 @Entity
 data class Place(

--- a/app/src/main/java/model/transcript/Transcript.kt
+++ b/app/src/main/java/model/transcript/Transcript.kt
@@ -25,9 +25,9 @@ import androidx.room.PrimaryKey
  * @author Julien Guerinet
  * @since 1.0.0
  *
- * @param totalCredits  User's total number of credits
- * @param cgpa          User's cumulative GPA
- * @param id            Transcript Id
+ * @property totalCredits  User's total number of credits
+ * @property cgpa          User's cumulative GPA
+ * @property id            Transcript Id
  */
 @Entity
 data class Transcript(

--- a/app/src/main/java/model/transcript/TranscriptCourse.kt
+++ b/app/src/main/java/model/transcript/TranscriptCourse.kt
@@ -27,14 +27,14 @@ import com.guerinet.mymartlet.model.Term
  * @author Julien Guerinet
  * @since 1.0.0
  *
- * @param semesterId    Id of the [Semester] this is for
- * @param term          Course currentTerm
- * @param courseCode    Course code (e.g. ECSE 428)
- * @param courseTitle   Course title
- * @param credits       Course credits
- * @param userGrade     User's grade in this course
- * @param averageGrade  Average grade in this course
- * @param id            Self managed Id, used as primary key
+ * @property semesterId    Id of the [Semester] this is for
+ * @property term          Course currentTerm
+ * @property courseCode    Course code (e.g. ECSE 428)
+ * @property courseTitle   Course title
+ * @property credits       Course credits
+ * @property userGrade     User's grade in this course
+ * @property averageGrade  Average grade in this course
+ * @property id            Self managed Id, used as primary key
  */
 @Entity
 data class TranscriptCourse(

--- a/app/src/main/java/ui/settings/about/PersonAdapter.kt
+++ b/app/src/main/java/ui/settings/about/PersonAdapter.kt
@@ -218,11 +218,11 @@ class PersonAdapter internal constructor() : BaseRecyclerViewAdapter(), KoinComp
  * @author Julien Guerinet
  * @since 2.0.0
  *
- * @param name        Person's name
- * @param pictureId   Person's picture
- * @param role        Person's role
- * @param email       Person's email
- * @param linkedIn    URL to the person's LinkedIn
+ * @property name        Person's name
+ * @property pictureId   Person's picture
+ * @property role        Person's role
+ * @property email       Person's email
+ * @property linkedIn    URL to the person's LinkedIn
  */
 private class Person(
     @StringRes val name: Int,

--- a/app/src/main/java/ui/walkthrough/WalkthroughAdapter.kt
+++ b/app/src/main/java/ui/walkthrough/WalkthroughAdapter.kt
@@ -40,7 +40,7 @@ import java.util.Comparator
  * @author Julien Guerinet
  * @version 2.1.0
  *
- * @param isFirstOpen   True if this is the first open, false otherwise
+ * @property isFirstOpen   True if this is the first open, false otherwise
  *                      For a first open there is an extra page at the end
  */
 class WalkthroughAdapter(private val isFirstOpen: Boolean) :

--- a/app/src/main/java/ui/wishlist/WishlistHelper.kt
+++ b/app/src/main/java/ui/wishlist/WishlistHelper.kt
@@ -44,9 +44,9 @@ import retrofit2.Response
  * @author Julien Guerinet
  * @since 1.0.0
  *
- * @param activity  Calling activity instance
+ * @property activity  Calling activity instance
  * @param container View to manipulate
- * @param canAdd    True if the user can add courses to the wishlist, false otherwise
+ * @property canAdd    True if the user can add courses to the wishlist, false otherwise
  */
 class WishlistHelper(
     private val activity: BaseActivity, container: View,

--- a/app/src/main/java/util/manager/HomepageManager.kt
+++ b/app/src/main/java/util/manager/HomepageManager.kt
@@ -42,7 +42,7 @@ import kotlin.reflect.KClass
  * @since 1.0.0
  *
  * @param prefs     [SharedPreferences] instance
- * @param context   App context
+ * @property context   App context
  */
 class HomepageManager(prefs: SharedPreferences, private val context: Context) : IntPref(
     prefs,
@@ -86,9 +86,9 @@ class HomepageManager(prefs: SharedPreferences, private val context: Context) : 
     /**
      * A potential home page for the app
      *
-     * @param titleId   Id of the title of the his home page
-     * @param menuId    Id of the menu item for this home page
-     * @param activity  Corresponding activity to open for this home page
+     * @property titleId   Id of the title of the his home page
+     * @property menuId    Id of the menu item for this home page
+     * @property activity  Corresponding activity to open for this home page
      */
     enum class HomePage(
         @StringRes val titleId: Int, @IdRes val menuId: Int,

--- a/app/src/main/java/util/manager/McGillManager.kt
+++ b/app/src/main/java/util/manager/McGillManager.kt
@@ -49,7 +49,7 @@ import java.io.IOException
  * @since 1.0.0
  *
  * @param loggingInterceptor    [HttpLoggingInterceptor] instance
- * @param usernamePref          [UsernamePref] instance
+ * @property usernamePref          [UsernamePref] instance
  */
 class McGillManager(
     loggingInterceptor: HttpLoggingInterceptor,

--- a/app/src/main/java/util/manager/UpdateManager.kt
+++ b/app/src/main/java/util/manager/UpdateManager.kt
@@ -28,7 +28,7 @@ import com.guerinet.suitcase.util.BaseUpdateManager
  * @since 1.0.0
  *
  * @param prefs     [SharedPreferences] instance
- * @param updateDao Dao to save the [AppUpdate]
+ * @property updateDao Dao to save the [AppUpdate]
  */
 class UpdateManager(
     prefs: SharedPreferences,


### PR DESCRIPTION
I converted all params to markup annotation and applied ktlint. Turns out it ignores extra whitespace if it's after square brackets, so you'll preserve your alignments.

With markup, some parameter annotations, such as constructor values that aren't kept, don't actually exist, so they aren't linked.