### PR TITLE
Update dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,19 +137,20 @@ android.buildTypes.each { type ->
 }
 
 // Versions for libraries with multiple dependencies
+def anko_version='0.10.7'
 def koin_version = "1.0.1"
 def okhttp_version = "3.11.0"
-def play_services_version = "11.0.4"
+def play_services_version = "16.0.7"
 def retrofit_version = "2.4.0"
 def room_version = "2.0.0"
 def suitcase_version = "4.9.0"
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.core:core-ktx:1.0.0'
+    implementation 'androidx.core:core-ktx:1.0.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
     kapt "androidx.lifecycle:lifecycle-compiler:$room_version"
@@ -157,7 +158,7 @@ dependencies {
     implementation "androidx.room:room-runtime:$room_version"
     kapt 'androidx.room:room-compiler:2.0.0'
     implementation "com.afollestad.material-dialogs:commons:0.9.6.0"
-    implementation("com.crashlytics.sdk.android:crashlytics:2.9.5@aar") {
+    implementation("com.crashlytics.sdk.android:crashlytics:2.9.9@aar") {
         transitive = true
     }
     implementation "com.facebook.android:facebook-android-sdk:4.38.0"
@@ -193,7 +194,7 @@ dependencies {
     }
     implementation "org.jetbrains.anko:anko-commons:$anko_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.0.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.0"
     // Don't update this as 1.10.x breaks the converters
     implementation "org.jsoup:jsoup:1.9.1"
     implementation "org.koin:koin-android:$koin_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -181,10 +181,10 @@ dependencies {
     implementation "com.jakewharton.timber:timber:4.7.1"
     implementation "com.orhanobut:hawk:2.0.1"
     implementation 'com.romandanylyk:pageindicatorview:1.0.3'
-    implementation "com.squareup.moshi:moshi:1.7.0"
+    implementation "com.squareup.moshi:moshi:1.8.0"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp_version"
     implementation "com.squareup.okhttp3:okhttp:$okhttp_version"
-    implementation "com.squareup.okio:okio:2.1.0"
+    implementation "com.squareup.okio:okio:2.2.2"
     implementation "com.squareup.picasso:picasso:2.71828"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofit_version"
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
@@ -199,7 +199,6 @@ dependencies {
     implementation "org.koin:koin-android:$koin_version"
     implementation "org.koin:koin-androidx-scope:$koin_version"
     implementation "org.koin:koin-androidx-viewmodel:$koin_version"
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,10 +137,9 @@ android.buildTypes.each { type ->
 }
 
 // Versions for libraries with multiple dependencies
-def anko_version='0.10.7'
-def koin_version = "1.0.1"
-def okhttp_version = "3.11.0"
-def play_services_version = "16.0.7"
+def anko_version='0.10.8'
+def koin_version = "1.0.2"
+def okhttp_version = "3.13.1"
 def retrofit_version = "2.4.0"
 def room_version = "2.0.0"
 def suitcase_version = "4.9.0"
@@ -162,8 +161,8 @@ dependencies {
         transitive = true
     }
     implementation "com.facebook.android:facebook-android-sdk:4.38.0"
-    implementation "com.google.android.gms:play-services-analytics:$play_services_version"
-    implementation "com.google.android.gms:play-services-maps:$play_services_version"
+    implementation "com.google.android.gms:play-services-analytics:16.0.7"
+    implementation "com.google.android.gms:play-services-maps:16.1.0"
     implementation 'com.google.android.material:material:1.0.0'
     implementation "com.guerinet:morf:6.0.0"
     implementation "com.guerinet.suitcase:analytics:$suitcase_version"

--- a/build.gradle
+++ b/build.gradle
@@ -18,17 +18,16 @@ apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'kotlin'
 
 buildscript {
-    ext.anko_version='0.10.7'
-    ext.kotlin_version = '1.3.0'
+    ext.kotlin_version = '1.3.21'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.google.gms:google-services:4.2.0'
         classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.17.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }


### PR DESCRIPTION
Updating most of the dependencies to the newer variants.

I'm mainly doing this to get rid of the warning:

```
API 'variant.getExternalNativeBuildTasks()' is obsolete and has been replaced with 'variant.getExternalNativeBuildProviders()'.
It will be removed at the end of 2019.
For more information, see https://d.android.com/r/tools/task-configuration-avoidance.
To determine what is calling variant.getExternalNativeBuildTasks(), use -Pandroid.debug.obsoleteApi=true on the command line to display a stack trace.
```

which seems to come from crashlytics

See https://github.com/firebase/firebase-android-sdk/issues/198